### PR TITLE
fixes social icon underlines

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -35,22 +35,22 @@ export default function(props) {
                     <View style={{flex: 1, flexDirection: 'row', justifyContent: 'space-around', paddingTop: 40, paddingBottom: 40}}>
                         <View>
                             <Link href="https://www.instagram.com/spicygreenbook/">
-                                <FontAwesome name="instagram" size={32} color="#fff" />
+                                <FontAwesome name="instagram" size={28} color="#fff" />
                             </Link>
                         </View>
                         <View>
                             <Link href="https://twitter.com/spicygreenbook">
-                                <FontAwesome name="twitter" size={32} color="#fff" />
+                                <FontAwesome name="twitter" size={28} color="#fff" />
                             </Link>
                         </View>
                         <View>
                             <Link href="https://www.linkedin.com/company/spicy-green-book/">
-                                <FontAwesome name="linkedin" size={32} color="#fff" />
+                                <FontAwesome name="linkedin" size={28} color="#fff" />
                             </Link>
                             </View>
                         <View>
                             <Link href="https://www.facebook.com/SpicyGreenBook/">
-                                <FontAwesome name="facebook" size={32} color="#fff" />
+                                <FontAwesome name="facebook" size={28} color="#fff" />
                             </Link>
                         </View>
                     </View>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -35,22 +35,22 @@ export default function(props) {
                     <View style={{flex: 1, flexDirection: 'row', justifyContent: 'space-around', paddingTop: 40, paddingBottom: 40}}>
                         <View>
                             <Link href="https://www.instagram.com/spicygreenbook/">
-                                <FontAwesome name="instagram" size={28} color="#fff" />
+                                <FontAwesome name="instagram" size={32} color="#fff" />
                             </Link>
                         </View>
                         <View>
                             <Link href="https://twitter.com/spicygreenbook">
-                                <FontAwesome name="twitter" size={28} color="#fff" />
+                                <FontAwesome name="twitter" size={32} color="#fff" />
                             </Link>
                         </View>
                         <View>
                             <Link href="https://www.linkedin.com/company/spicy-green-book/">
-                                <FontAwesome name="linkedin" size={28} color="#fff" />
+                                <FontAwesome name="linkedin" size={32} color="#fff" />
                             </Link>
                             </View>
                         <View>
                             <Link href="https://www.facebook.com/SpicyGreenBook/">
-                                <FontAwesome name="facebook" size={28} color="#fff" />
+                                <FontAwesome name="facebook" size={32} color="#fff" />
                             </Link>
                         </View>
                     </View>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7625,6 +7625,14 @@
         "url-parse": "^1.4.4"
       }
     },
+    "expo-blur": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/expo-blur/-/expo-blur-8.1.2.tgz",
+      "integrity": "sha512-Z/NCe59rDR9D54FEZNisRybZwihfE9EQfolgchmra9wt89eryXMtxR9ciHn6n0F/BImOiS6UhzQZIE4SRs76Eg==",
+      "requires": {
+        "prop-types": "^15.6.0"
+      }
+    },
     "expo-constants": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-9.1.1.tgz",

--- a/public/site.css
+++ b/public/site.css
@@ -1,4 +1,4 @@
-#nav a:hover, #nav a:hover > div, #footer a:hover, #footer a:hover > div, #homeLinks a:hover, #homeLinks a:hover > div {
+#nav a:hover, #nav a:hover > div, #footer a:hover, #homeLinks a:hover, #homeLinks a:hover > div {
     text-decoration: underline;
 }
 


### PR DESCRIPTION
Social icons in footer were too large and interfering with the text underline. Reducing size from 32 to 28 fixed the problem.

Other suggestion is to eliminate the underlines-on-hover all together, just for the social icons, and leave them at their original size. Happy to redo the pull request if you want to go that route!