### PR TITLE
Handle case where press row is missing a name property

### DIFF
--- a/screens/Home.js
+++ b/screens/Home.js
@@ -135,7 +135,7 @@ function Page(props) {
                     ) : (
                         <React.Fragment>
                             {press.filter(pressRow => pressRow.press_site_logo_white).sort((a, b) => {
-                                if (a.name.indexOf('ABC') > -1) { return -1; }
+                                if (a.name && a.name.indexOf('ABC') > -1) { return -1; }
                                 return 0;
                             }).map((pressRow, p) => 
                                 (<View style={{width: GridWidth({minWidth: 140}), margin: 20}} key={'press' + p}>


### PR DESCRIPTION
Fixes #67. For some reason `name` was not defined on a press row item, so this checks whether the property exists before trying to call `indexOf` on it.