### PR TITLE
Fix instagram error handling, clean up data fetching

### DIFF
--- a/components/Attribution.js
+++ b/components/Attribution.js
@@ -3,7 +3,7 @@ import { useStateValue } from "../components/State";
 import {View, Text, StyleSheet, Button, Platform, ActivityIndicator, FlatList, Image} from 'react-native';
 import { Link } from "../components/Link"; 
 import { RichText } from "../components/RichText"; 
-import { getStyles, Theme, getContent, getData, getDataAsync } from '../utils';
+import { getStyles, Theme, getContent, getData } from '../utils';
 import { FontAwesome } from '@expo/vector-icons'; 
 
 function Attribution(props) {

--- a/screens/Home.js
+++ b/screens/Home.js
@@ -34,7 +34,6 @@ function Page(props) {
     const [ updates, setUpdates ] = useState(props.updates || []);
 
     const [ loadingInstagram, setLoadingInstagram ] = useState(true);
-    const [ errorInstagram, setErrorInstagram ] = useState('');
     const [ instagram, setInstagram ] = useState([]);
 
     const [ loadingListings, setLoadingListings ] = useState(!props.listings);

--- a/screens/Home.js
+++ b/screens/Home.js
@@ -4,10 +4,11 @@ import { StyleSheet, View, ScrollView, FlatList, Text, Button, SGBButton, Image,
 import { Link } from "../components/Link"; 
 import { ResponsiveImage } from "../components/ResponsiveImage"; 
 import RichText from "../components/RichText"; 
-import { getStyles, Theme, getDataAsync, GridWidth, displayDate } from '../utils';
+import { getStyles, Theme, getData, GridWidth } from '../utils';
 import { Entypo } from '@expo/vector-icons'; 
 import Search from "../components/Search";
 import SGBMap from "../components/SGBMap";
+import { getInstagram } from '../utils/getData';
 
 let currentIndexListing = 0;
 const viewableItemsChangedListing = ({ viewableItems, changed }) => {
@@ -43,7 +44,7 @@ function Page(props) {
     useEffect( () => {
 
         if (!props.press) {
-            getDataAsync({
+            getData({
                 type: 'press'
             }).then(press => {
                 console.log('press izz', press)
@@ -59,7 +60,7 @@ function Page(props) {
         }
 
         if (!props.updates) {
-            getDataAsync({
+            getData({
                 type: 'updates'
             }).then(updates => {
                 console.log('updates izz', updates)
@@ -72,20 +73,13 @@ function Page(props) {
             })
         }
 
-        getDataAsync({
-            type: 'instagram'
-        }).then(instagram => {
-            console.log('instagram izz', instagram)
+        getInstagram().then(instagram => {
             setLoadingInstagram(false);
             setInstagram(instagram)
-        }).catch(err => {
-            console.error(err);
-            setLoadingInstagram(false);
-            setErrorInstagram('Failed to load latest instagram.');
-        })
+        });
 
         if (!props.listings) {
-            getDataAsync({
+            getData({
                 type: 'listing'
             }).then(listings => {
                 console.log('Listings izz', listings)

--- a/screens/Press.js
+++ b/screens/Press.js
@@ -3,7 +3,7 @@ import { useStateValue } from "../components/State";
 import {View, Text, StyleSheet, Button, Platform, ActivityIndicator, FlatList, Image} from 'react-native';
 import { Link } from "../components/Link"; 
 import { RichText } from "../components/RichText"; 
-import { getStyles, Theme, getContent, getData, getDataAsync } from '../utils';
+import { getStyles, Theme, getContent, getData } from '../utils';
 import { ResponsiveImage } from "../components/ResponsiveImage"
 
 function Page(props) {
@@ -33,7 +33,7 @@ function Page(props) {
 
     useEffect( () => {
         if (!props.press) {
-            getDataAsync({
+            getData({
                 type: 'press'
             }).then(press => {
                 console.log('press izz', press)

--- a/screens/Team.js
+++ b/screens/Team.js
@@ -3,7 +3,7 @@ import { useStateValue } from "../components/State";
 import {View, Text, StyleSheet, Button, Platform, ActivityIndicator, FlatList, Image} from 'react-native';
 import { Link } from "../components/Link"; 
 import { RichText } from "../components/RichText"; 
-import { getStyles, Theme, getContent, getData, getDataAsync } from '../utils';
+import { getStyles, Theme, getContent, getData } from '../utils';
 import { ResponsiveImage } from "../components/ResponsiveImage"; 
 
 
@@ -34,7 +34,7 @@ function Page(props) {
 
     useEffect( () => {
         if (!props.staff) {
-            getDataAsync({
+            getData({
                 type: 'staff'
             }).then(staff => {
                 console.log('staff izz', staff)

--- a/screens/Updates.js
+++ b/screens/Updates.js
@@ -4,7 +4,7 @@ import {View, Text, StyleSheet, Button, Platform, ActivityIndicator, FlatList, I
 import { Link } from "../components/Link"; 
 import { RichText } from "../components/RichText"; 
 import Attribution from "../components/Attribution"; 
-import { getStyles, Theme, getContent, getData, getDataAsync } from '../utils';
+import { getStyles, Theme, getContent, getData } from '../utils';
 
 
 function Page(props) {
@@ -34,7 +34,7 @@ function Page(props) {
 
     useEffect( () => {
         if (!props.updates) {
-            getDataAsync({
+            getData({
                 type: 'updates'
             }).then(updates => {
                 console.log('updates izz', updates)

--- a/utils/getData.js
+++ b/utils/getData.js
@@ -178,6 +178,23 @@ export async function getContent(config) {
     }
 }
 
+const isLocalWeb = () => (
+    typeof window !== 'undefined' && window.location && window.location.host.indexOf('localhost') > -1
+);
+
+export async function getInstagram() {
+    const url = isLocalWeb() ? 'http://localhost:3000/api/instagram' : 'https://spicygreenbook.com/api/instagram';
+    try {
+        const result = await fetch(url);
+        const data = await result.json();
+        if (data.error) throw data;
+        return data;
+    } catch (e) {
+        console.error(e);
+        return [];
+    }
+}
+
 export async function getData(config) {
     if (!config){ config = {}; }
     if (!config.limit) {config.limit = 100}
@@ -205,8 +222,6 @@ export async function getData(config) {
         url = `https://spicygreenbook.cdn.prismic.io/api/v1/documents/search?ref=${master_ref}&q=%5B%5Bat(document.type%2C+%22${config.type}%22)%5D%5D&orderings=%5Bmy.staff.order%20desc%5D${config.limit ? ('&pageSize=' + config.limit) : ''}`;
     } else if (config.type === 'press') {
         url = `https://spicygreenbook.cdn.prismic.io/api/v1/documents/search?ref=${master_ref}&q=%5B%5Bat(document.type%2C+%22${config.type}%22)%5D%5D&orderings=%5Bmy.press.date%20desc%5D${config.limit ? ('&pageSize=' + config.limit) : ''}`;
-    } else if (config.type === 'instagram') {
-        url = typeof window !== 'undefined' && window.location && window.location.host.indexOf('localhost') > -1 ? `http://localhost:3000/api/instagram` : `https://spicygreenbook.com/api/instagram`
     }
     if (url) {
         let data;
@@ -215,14 +230,7 @@ export async function getData(config) {
         } catch(e) {
             console.log('failed to fetch', url)
         }
-        if (config.type === 'instagram') {
-            try {
-                rows = await data.json();
-            } catch(e) {
-                console.log('failed to parse instagram');
-            }
-        } else {
-            let parsed_data = [];
+        let parsed_data = [];
             let getLoop = async (nextInfo) => {
                 nextInfo.results.map((doc, i) => {
                     parsed_data.push(doc);
@@ -290,28 +298,16 @@ export async function getData(config) {
                     return true;
                 }
             })
-        }
     }
     return rows
 }
 
 export async function getAllData(config) {
-    let types = ['listing', 'updates', 'press', 'staff', 'instagram'];
+    let types = ['listing', 'updates', 'press', 'staff'];
     let ret = {};
     types.forEach(type => {
         /*ret[type] = async getData({
             type: type
         })*/
-    })
-}
-
-export const getDataAsync = (config) => {
-    return new Promise(async (resolve, reject) => {
-        try {
-            let ret = await getData(config);
-            resolve(ret);
-        } catch(e) {
-            reject(e);
-        }
     })
 }

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,4 +1,4 @@
-export { getData, getDataAsync, getAllData, getContent } from './getData';
+export { getData, getAllData, getContent } from './getData';
 export { getStyles, Theme, GridWidth, responsiveImageWidthCDN } from './getStyles';
 export { getImage } from './getImage';
 export { StateReducer, InitialState} from './StateReducer';


### PR DESCRIPTION
Fixes #89. Fixes instagram api error handling. Previously, if the call failed the promise would still resolve successfully with an error object. The home page handled that as a success case and tried to set the list of instagram items to an object, which broke the list renderer.

This also removes the `getDataAsync` function which unnecessarily wrapped a function `getData` that is already async.