### PR TITLE
Updates page redesign

### DIFF
--- a/public/site.css
+++ b/public/site.css
@@ -1,4 +1,4 @@
-#nav a:hover, #nav a:hover > div, #footer a:hover, #homeLinks a:hover, #homeLinks a:hover > div {
+#nav a:hover, #nav a:hover > div, #footer a:hover, #homeLinks a:hover, #homeLinks a:hover > div, #updatesLinks a:hover > div > div {
     text-decoration: underline;
 }
 

--- a/screens/Updates.js
+++ b/screens/Updates.js
@@ -5,12 +5,18 @@ import { Link } from "../components/Link";
 import { RichText } from "../components/RichText"; 
 import Attribution from "../components/Attribution"; 
 import { getStyles, Theme, getContent, getData } from '../utils';
+import { ResponsiveImage } from "../components/ResponsiveImage";
 
 
 function Page(props) {
 
     const [{ view, isWeb, dimensions }, dispatch] = useStateValue();
-    const styles = StyleSheet.create(getStyles('text_header2, text_header4, section, content', {isWeb}));
+    const styles = StyleSheet.create(
+      getStyles(
+        "text_header2, text_header4, text_header5, section, content",
+        { isWeb }
+      )
+    );
     //console.log('page props', props)
 
     const [ pageLoading, setPageLoading ] = useState(props.content ? false: true);
@@ -48,59 +54,135 @@ function Page(props) {
         }
     }, [])
 
+    let numColumns =
+          dimensions.width < 600 ? 1 : dimensions.width < 1000 ? 2 : 3;
+
+    let hasBody = content.body && content.body.join("");
+
     return (
-        <React.Fragment>
-        { pageLoading ?
-            <View style={{marginTop: 200, marginBottom: 200}}>
-                <ActivityIndicator color={Theme.green} size="large" />
+      <React.Fragment>
+        {pageLoading ? (
+          <View style={{ marginTop: 200, marginBottom: 200 }}>
+            <ActivityIndicator color={Theme.green} size="large" />
+          </View>
+        ) : (
+          <React.Fragment>
+            <View
+              style={[
+                styles.section,
+                { backgroundColor: Theme.green_bg, paddingTop: 180 },
+              ]}
+            >
+              <View
+                style={[
+                  styles.content,
+                  { flexDirection: "column", alignItems: "center" },
+                ]}
+              >
+                <Text
+                  accessibilityRole="header"
+                  aria-level="2"
+                  style={[styles.text_header2, { color: "#fff" }]}
+                >
+                  {content.page_title}
+                </Text>
+              </View>
             </View>
-        : (
-            <React.Fragment>
-                <View style={[styles.section, {backgroundColor: Theme.green_bg, paddingTop: 180}]}>
-                    <View style={[styles.content, {flexDirection: 'column', alignItems: 'center'}]}>
-                        <Text accessibilityRole="header" aria-level="2" style={[styles.text_header2, {color: '#fff'}]}>{content.page_title}</Text>
-                    </View>
-                </View>
-                <View style={[styles.section]}>
-                    <View style={styles.content}>
-                        <RichText render={content._body} isWeb={isWeb} />
-                    </View>
-                </View>
-                <View style={[styles.section]}>
-                    <View style={styles.content}>
-                        {loadingUpdates ? (
-                            <ActivityIndicator color={Theme.green} size="large" />
-                        ) : errorUpdates ? (
-                            <Text>{errorUpdates}</Text>
-                        ) : (
-                            <FlatList
-                                data={updates}
-                                ItemSeparatorComponent={highlighted => <View style={{paddingTop: 80}}></View>}
-                                renderItem={({ item, index, separators }) => (
-                                    <View style={{flexDirection: 'row'}} key={'update' + index}>
-                                        <View style={{flex: 1, flexDirection: 'row'}}>
-                                            <Image style={{width: '100%', aspectRatio: 1}} source={{uri: item.image.url + '&w=600'}} />
-                                        </View>
-                                        <View style={{flex: 3, paddingLeft: 20}}>
-                                            <Text style={styles.text_header4}>{item.title}</Text>
-                                            <Text>{item.date}</Text>
-                                            <RichText render={item._body} isWeb={isWeb} />
+            {!!hasBody && <View style={[styles.section]}>
+              <View style={styles.content}>
+                <RichText render={content._body} isWeb={isWeb} />
+              </View>
+            </View>}
+            <View style={[styles.section]} nativeID="updatesLinks">
+              <View style={styles.content}>
+                {loadingUpdates ? (
+                  <ActivityIndicator color={Theme.green} size="large" />
+                ) : errorUpdates ? (
+                  <Text>{errorUpdates}</Text>
+                ) : (
+                  <FlatList
+                    key={"cols" + numColumns}
+                    data={updates}
+                    numColumns={numColumns}
+                    ItemSeparatorComponent={(highlighted) => (
+                      <View style={{ paddingTop: 80 }}></View>
+                    )}
+                    renderItem={({ item, index, separators }) => (
+                      <View
+                        style={{ flexDirection: "row" }}
+                        key={"update" + index}
+                        style={{
+                          flex: 1 / numColumns,
+                          // justifyContent: "space-between",
+                          margin: 10,
+                          borderTopWidth: 2,
+                          borderColor: Theme.green,
+                          shadowColor: "#000",
+                          shadowOffset: {
+                            width: 0,
+                            height: 3,
+                          },
+                          shadowOpacity: 0.27,
+                          shadowRadius: 4.65,
 
-                                            {!!item.action_text && !!item.link && <Link href={item.link} button={'button_green'} title={item.action_text} />}
-
-                                            {!!(item.attribution && item.attribution.length) && <Attribution attribution={item.attribution} />}
-                                        </View>
-                                    </View>
-                                )}
-                                keyExtractor={(item, index) => 'update' + index}
-                            />
+                          elevation: 6,
+                        }}
+                      >
+                        {item.image && item.image.url && (
+                          <ResponsiveImage
+                            style={{
+                              maxWidth: "100%",
+                              width: item.image.width,
+                              height: item.image.height,
+                            }}
+                            source={{ uri: item.image.url + "&w=600" }}
+                          />
                         )}
-                    </View>
-                </View>
-            </React.Fragment>
+
+                        <View
+                          style={{
+                            flex: 1,
+                            padding: 20,
+                          }}
+                        >
+                          <View>
+                            <Text>{item.date}</Text>
+                            <Text style={styles.text_header5}>
+                              {item.title}
+                            </Text>
+                          </View>
+
+                          <View>
+                            <RichText render={item._body} isWeb={isWeb} />
+                          </View>
+
+                          {!!item.action_text && !!item.link && (
+                            <View style={{ marginTop: "auto" }}>
+                              <Link href={item.link}>
+                                <View>
+                                  <Text style={[styles.text_header4]}>
+                                    {item.action_text} &gt;
+                                  </Text>
+                                </View>
+                              </Link>
+                            </View>
+                          )}
+
+                          {!!(item.attribution && item.attribution.length) && (
+                            <Attribution attribution={item.attribution} />
+                          )}
+                        </View>
+                      </View>
+                    )}
+                    keyExtractor={(item, index) => "update" + index}
+                  />
+                )}
+              </View>
+            </View>
+          </React.Fragment>
         )}
-        </React.Fragment>
-    )
+      </React.Fragment>
+    );
 }
 
 const styles = StyleSheet.create({

--- a/utils/getStyles.js
+++ b/utils/getStyles.js
@@ -6,255 +6,264 @@ const theme = {
 }
 
 const allStyles = {
-    nav: function(config) {
-        let ret = {
-            left: 0,
-            top: 0,
-            right: 0,
-            height: config.isWeb ? 120 : 160,
-            paddingTop: config.isWeb ? 0 : 40,
-            flex: 1,
-            flexDirection: 'row',
-            zIndex: 2,
-            elevation: 2
-            //backgroundColor: '#000'
-        }
-        if (config.isWeb) {
-            ret.position = 'fixed'
-        } else {
-            ret.position = 'absolute';
-        }
-        return ret
-    },
-    footer: function(config) {
-        return {
-            zIndex: 2,
-            elevation: 2,
-            backgroundColor: theme.green_bg
-        }
-    },
-    body: function(config) {
-        return {
-            zIndex: 1,
-            elevation: 1,
-            marginTop: config.isWeb ? 0 : 40
-        }
-    },
-    section: function(config) {
-        return {
-            padding: 20,
-            paddingTop: 80,
-            paddingBottom: 80,
-            alignContent: 'center',
-            alignItems: 'center',
-            flexDirection: 'column',
-            justifyContent: 'center'
-        }
-    },
-    content: function(config) {
-        return {
-            maxWidth: '100%',
-            width: 1024
-        }
-    },
-    image_fill: function(config) {
-        return {
-            position: 'absolute',
-            left: 0,
-            top: 0,
-            bottom: 0,
-            right: 0,
-            resizeMode: 'cover'
-        }
-    },
-    text_hero: function(config) {
-        return {
-            textAlign: 'left',
-            fontFamily: 'KnockoutBold',
-            fontSize: config.windowWidth < 900 ? 48 : 82,
-            lineHeight: config.windowWidth < 900 ? 50 : 98,
-            textTransform: 'uppercase',
-            color: '#fff'
-        }
-    },
-    text_nav: function(config) {
-        return {
-            fontFamily: 'ApercuMedium',
-            fontSize: 18,
-            textTransform: 'uppercase',
-            color: config.theme === 'light' ? theme.green : '#fff'
-        }
-    },
-    text_nav_sub: function(config) {
-        return {
-            fontFamily: 'ApercuMedium',
-            fontSize: 16,
-            textTransform: 'uppercase',
-            color: theme.green
-        }
-    },
-    text_footer: function(config) {
-        return {
-            fontFamily: 'ApercuMedium',
-            fontSize: config.windowWidth < 600 ? 12 : 18,
-            textTransform: 'uppercase',
-            color: '#fff'
-        }
-    },
-    text_header: function(config) {
-        return {
-            fontFamily: 'KnockoutBold',
-            fontSize: config.windowWidth < 900 ? 45 : 75,
-            lineHeight: config.windowWidth < 900 ? 46 : 90,
-            textTransform: 'uppercase',
-            color: '#006233'
-        }
-    },
-    text_header2: function(config) {
-        return {
-            fontFamily: 'KnockoutBold',
-            fontSize: config.windowWidth < 900 ? 40 : 75,
-            lineHeight: config.windowWidth < 900 ? 42 : 66,
-            textTransform: 'uppercase',
-            color: '#006233'
-        }
-    },
-    text_header3: function(config) {
-        return {
-            fontFamily: 'KnockoutFeatherWeight',
-            fontSize: config.windowWidth < 900 ? 38 : 45,
-            lineHeight: config.windowWidth < 900 ? 38 : 66,
-            textTransform: 'uppercase',
-            color: '#006233'
-        }
-    },
-    text_header4: function(config) {
-        return {
-            fontFamily: 'KnockoutWelterWeight',
-            fontSize: config.windowWidth < 900 ? 16 : 24,
-            lineHeight: config.windowWidth < 900 ? 20 : 29,
-            textTransform: 'uppercase',
-            color: '#006233'
-        }
-    },
-    text_header6: function(config) {
-        return {
-            fontFamily: 'ApercuMedium',
-            fontSize: config.windowWidth < 900 ? 20 : 24,
-            lineHeight: config.windowWidth < 900 ? 28 : 32,
-            color: '#000'
-        }
-    },
-    text_body: function(config) {
-        return {
-            fontFamily: 'ApercuMedium',
-            fontSize: config.windowWidth < 900 ? 20 : 24,
-            lineHeight: config.windowWidth < 900 ? 28 : 32,
-            color: '#606060'
-        }
-    },
-    text_body2: function(config) {
-        return {
-            fontFamily: 'ApercuMedium',
-            fontSize: config.windowWidth < 900 ? 16 : 22,
-            lineHeight: config.windowWidth < 900 ? 20 : 28,
-            color: '#606060'
-        }
-    },
-    text_body3: function(config) {
-        return {
-            fontFamily: 'ApercuMedium',
-            fontSize: 16,
-            //color: '#006233'
-        }
-    },
-    text_link: function(config) {
-        return {
-            fontFamily: 'ApercuMedium',
-            fontSize: config.windowWidth < 900 ? 15 : 32,
-            lineHeight: config.windowWidth < 900 ? 20 : 42,
-            color: '#006233'
-        }
-    },
-    text_quote: function(config) {
-        return {
-            fontFamily: 'ApercuLight',
-            fontStyle: 'italic',
-            fontSize: config.windowWidth < 900 ? 55 : 28,
-            lineHeight: config.windowWidth < 900 ? 65 : 36,
-            color: '#006233'
-        }
-    },
-    middle_all: function(config) {
-        return {
-            flex: 1,
-            justifyContent: 'center',
-            alignItems: 'center'
-        }
-    },
-    button_white: function(config) {
-        return {
-            borderWidth: 1,
-            borderColor: '#fff',
-            backgroundColor: 'rgba(0,0,0,0)',
-            alignItems: 'center',
-            height: 80,
-            paddingLeft: 60,
-            paddingRight: 60,
-            flexDirection: 'row'
-        }
-    },
-    button_white_text: function(config) {
-        return {
-            textTransform: 'uppercase',
-            fontFamily: 'ApercuMedium',
-            fontSize: 16,
-            lineHeight: 15,
-            color: '#fff'
-        }
-    },
-    button_green: function(config) {
-        return {
-            borderWidth: 1,
-            borderColor: theme.green,
-            backgroundColor: theme.green_bg,
-            alignItems: 'center',
-            height: 60,
-            paddingLeft: 30,
-            paddingRight: 30,
-            flexDirection: 'row'
-        }
-    },
-    button_green_text: function(config) {
-        return {
-            textTransform: 'uppercase',
-            fontFamily: 'ApercuMedium',
-            fontSize: 16,
-            lineHeight: 15,
-            color: '#fff'
-        }
-    },
-    button_link: function(config) {
-        return {}
-    },
-    button_link_text: function(config) {
-        return {
-            fontFamily: 'ApercuMedium',
-            fontSize: 12,
-            lineHeight: 15,
-            color: Theme.green
-        }
-    },
-    text_menu: function(config) {
-        return {
-            textTransform: 'capitalize',
-            fontFamily: 'ApercuMedium',
-            fontSize: 24,
-            lineHeight: 29,
-            color: '#fff'
-        }
+  nav: function (config) {
+    let ret = {
+      left: 0,
+      top: 0,
+      right: 0,
+      height: config.isWeb ? 120 : 160,
+      paddingTop: config.isWeb ? 0 : 40,
+      flex: 1,
+      flexDirection: "row",
+      zIndex: 2,
+      elevation: 2,
+      //backgroundColor: '#000'
+    };
+    if (config.isWeb) {
+      ret.position = "fixed";
+    } else {
+      ret.position = "absolute";
     }
-}
+    return ret;
+  },
+  footer: function (config) {
+    return {
+      zIndex: 2,
+      elevation: 2,
+      backgroundColor: theme.green_bg,
+    };
+  },
+  body: function (config) {
+    return {
+      zIndex: 1,
+      elevation: 1,
+      marginTop: config.isWeb ? 0 : 40,
+    };
+  },
+  section: function (config) {
+    return {
+      padding: 20,
+      paddingTop: 80,
+      paddingBottom: 80,
+      alignContent: "center",
+      alignItems: "center",
+      flexDirection: "column",
+      justifyContent: "center",
+    };
+  },
+  content: function (config) {
+    return {
+      maxWidth: "100%",
+      width: 1024,
+    };
+  },
+  image_fill: function (config) {
+    return {
+      position: "absolute",
+      left: 0,
+      top: 0,
+      bottom: 0,
+      right: 0,
+      resizeMode: "cover",
+    };
+  },
+  text_hero: function (config) {
+    return {
+      textAlign: "left",
+      fontFamily: "KnockoutBold",
+      fontSize: config.windowWidth < 900 ? 48 : 82,
+      lineHeight: config.windowWidth < 900 ? 50 : 98,
+      textTransform: "uppercase",
+      color: "#fff",
+    };
+  },
+  text_nav: function (config) {
+    return {
+      fontFamily: "ApercuMedium",
+      fontSize: 18,
+      textTransform: "uppercase",
+      color: config.theme === "light" ? theme.green : "#fff",
+    };
+  },
+  text_nav_sub: function (config) {
+    return {
+      fontFamily: "ApercuMedium",
+      fontSize: 16,
+      textTransform: "uppercase",
+      color: theme.green,
+    };
+  },
+  text_footer: function (config) {
+    return {
+      fontFamily: "ApercuMedium",
+      fontSize: config.windowWidth < 600 ? 12 : 18,
+      textTransform: "uppercase",
+      color: "#fff",
+    };
+  },
+  text_header: function (config) {
+    return {
+      fontFamily: "KnockoutBold",
+      fontSize: config.windowWidth < 900 ? 45 : 75,
+      lineHeight: config.windowWidth < 900 ? 46 : 90,
+      textTransform: "uppercase",
+      color: "#006233",
+    };
+  },
+  text_header2: function (config) {
+    return {
+      fontFamily: "KnockoutBold",
+      fontSize: config.windowWidth < 900 ? 40 : 75,
+      lineHeight: config.windowWidth < 900 ? 42 : 66,
+      textTransform: "uppercase",
+      color: "#006233",
+    };
+  },
+  text_header3: function (config) {
+    return {
+      fontFamily: "KnockoutFeatherWeight",
+      fontSize: config.windowWidth < 900 ? 38 : 45,
+      lineHeight: config.windowWidth < 900 ? 38 : 66,
+      textTransform: "uppercase",
+      color: "#006233",
+    };
+  },
+  text_header4: function (config) {
+    return {
+      fontFamily: "KnockoutWelterWeight",
+      fontSize: config.windowWidth < 900 ? 16 : 24,
+      lineHeight: config.windowWidth < 900 ? 20 : 29,
+      textTransform: "uppercase",
+      color: "#006233",
+    };
+  },
+  text_header5: function (config) {
+    return {
+      fontFamily: "KnockoutWelterWeight",
+      fontSize: config.windowWidth < 900 ? 20 : 24,
+      lineHeight: config.windowWidth < 900 ? 28 : 32,
+      textTransform: "uppercase",
+      color: "#000",
+    };
+  },
+  text_header6: function (config) {
+    return {
+      fontFamily: "ApercuMedium",
+      fontSize: config.windowWidth < 900 ? 20 : 24,
+      lineHeight: config.windowWidth < 900 ? 28 : 32,
+      color: "#000",
+    };
+  },
+  text_body: function (config) {
+    return {
+      fontFamily: "ApercuMedium",
+      fontSize: config.windowWidth < 900 ? 20 : 24,
+      lineHeight: config.windowWidth < 900 ? 28 : 32,
+      color: "#606060",
+    };
+  },
+  text_body2: function (config) {
+    return {
+      fontFamily: "ApercuMedium",
+      fontSize: config.windowWidth < 900 ? 16 : 22,
+      lineHeight: config.windowWidth < 900 ? 20 : 28,
+      color: "#606060",
+    };
+  },
+  text_body3: function (config) {
+    return {
+      fontFamily: "ApercuMedium",
+      fontSize: 16,
+      //color: '#006233'
+    };
+  },
+  text_link: function (config) {
+    return {
+      fontFamily: "ApercuMedium",
+      fontSize: config.windowWidth < 900 ? 15 : 32,
+      lineHeight: config.windowWidth < 900 ? 20 : 42,
+      color: "#006233",
+    };
+  },
+  text_quote: function (config) {
+    return {
+      fontFamily: "ApercuLight",
+      fontStyle: "italic",
+      fontSize: config.windowWidth < 900 ? 55 : 28,
+      lineHeight: config.windowWidth < 900 ? 65 : 36,
+      color: "#006233",
+    };
+  },
+  middle_all: function (config) {
+    return {
+      flex: 1,
+      justifyContent: "center",
+      alignItems: "center",
+    };
+  },
+  button_white: function (config) {
+    return {
+      borderWidth: 1,
+      borderColor: "#fff",
+      backgroundColor: "rgba(0,0,0,0)",
+      alignItems: "center",
+      height: 80,
+      paddingLeft: 60,
+      paddingRight: 60,
+      flexDirection: "row",
+    };
+  },
+  button_white_text: function (config) {
+    return {
+      textTransform: "uppercase",
+      fontFamily: "ApercuMedium",
+      fontSize: 16,
+      lineHeight: 15,
+      color: "#fff",
+    };
+  },
+  button_green: function (config) {
+    return {
+      borderWidth: 1,
+      borderColor: theme.green,
+      backgroundColor: theme.green_bg,
+      alignItems: "center",
+      height: 60,
+      paddingLeft: 30,
+      paddingRight: 30,
+      flexDirection: "row",
+    };
+  },
+  button_green_text: function (config) {
+    return {
+      textTransform: "uppercase",
+      fontFamily: "ApercuMedium",
+      fontSize: 16,
+      lineHeight: 15,
+      color: "#fff",
+    };
+  },
+  button_link: function (config) {
+    return {};
+  },
+  button_link_text: function (config) {
+    return {
+      fontFamily: "ApercuMedium",
+      fontSize: 12,
+      lineHeight: 15,
+      color: Theme.green,
+    };
+  },
+  text_menu: function (config) {
+    return {
+      textTransform: "capitalize",
+      fontFamily: "ApercuMedium",
+      fontSize: 24,
+      lineHeight: 29,
+      color: "#fff",
+    };
+  },
+};
 
 export function getStyles(key, config) {
     let ret = {};


### PR DESCRIPTION
Brings Updates page into alignment with the design pictured in #17. Adds new text_header5 style for update card titles, which looks like the designer's image, from what I can tell (sorry, my text editor reformatted that whole file which is why the diff is so long—just the text_header5 class was added). This is based on the changes already made to the Press page but now the "keep reading" links always align to the bottom of the card and underline on hover to indicate a clickable link.

Since the Press page and Updates page have some of the same links and are similar in design, I recommend updating the Press page to be fully in alignment with this new Updates design: image on top and following the same styling as the Updates page. Happy to take that on if you think it's a good idea!