### PR TITLE
Use absolute positioning instead of viewport units

### DIFF
--- a/components/Main.js
+++ b/components/Main.js
@@ -143,7 +143,7 @@ function Main(props) {
   }
 
   return (
-      <View style={isWeb ? {minHeight: '100vh', flex: 1}: {flex: 1}}>
+      <View style={isWeb ? {position: 'absolute', top: 0, right: 0, left: 0, bottom: 0, flex: 1}: {flex: 1}}>
           {lightbox && lightboxConfig.images ? (
             <React.Fragment>
               <ImageGallery images={lightboxConfig.images} firstIndex={lightboxConfig.index} />


### PR DESCRIPTION
Fixes #117. I'm having a hard time figuring out exactly why the `100vh` unit stopped working, but using absolute positioning instead fixes this issue. I think that maybe React Native doesn't support `vh`, so for some reason it wasn't adding this rule when it created the stylesheet for this component.