### PR TITLE
Force rerender on web to correct layout issues

### DIFF
--- a/components/Main.js
+++ b/components/Main.js
@@ -28,7 +28,7 @@ function Main(props) {
 
   const [{ view, isWeb, theme, menuOpen, dimensions, lightbox, lightboxConfig }, dispatch] = useStateValue();
   const [ isScrolled, setIsScrolled ] = useState(false);
-  // const [forceUpdate, setForceUpdate] = useState(0);
+  const [forceUpdate, setForceUpdate] = useState(0);
 
 
 /* debug purposes figureing out dispatches causing rerender  
@@ -85,7 +85,7 @@ function Main(props) {
 
   if (isWeb) {
     useEffect(() => {
-        // setForceUpdate(forceUpdate + 1);
+        setForceUpdate(forceUpdate + 1);
         window.addEventListener('scroll', scrollEventListener, false)
 
       return () => {
@@ -114,7 +114,7 @@ function Main(props) {
   }
 
   return (
-      <View style={isWeb ? {position: 'absolute', top: 0, right: 0, left: 0, bottom: 0, flex: 1}: {flex: 1}}>
+      <View key={forceUpdate} style={isWeb ? {position: 'absolute', top: 0, right: 0, left: 0, bottom: 0, flex: 1}: {flex: 1}}>
           {lightbox && lightboxConfig.images ? (
             <React.Fragment>
               <ImageGallery images={lightboxConfig.images} firstIndex={lightboxConfig.index} />


### PR DESCRIPTION
Fixes #143 . @mrvncaragay If you can think of a more elegant way to make this work please let me know. I don't think react is picking up the difference between the styles that are generated server-side from the ones in the client when it hydrates the page, so the mobile site is ending up with desktop styles if it doesn't rerender.