### PR TITLE
Fix go-back function at search page

### DIFF
--- a/components/Search.js
+++ b/components/Search.js
@@ -93,10 +93,8 @@ const Search = ({
     })
 
     if (isWeb) {
-      if(router.route !== '/search') {
-        const url = `/search?${new URLSearchParams(q).toString()}`;
-        router.push(url);
-      }
+      const url = `/search?${new URLSearchParams(q).toString()}`;
+      router.push(url);
       return;
     }
 


### PR DESCRIPTION
Closes #180 

In order to accomplish the task of allowing the _go back_ functionality the condition over the _URL_ must be deleted as shown in this _PR_. Please check that no processing time is exceeded.

I am happy to contribute to the project and hope to get more in touch with the needs of it.