### PR TITLE
238 press page enhancement

### DIFF
--- a/components/VolunteerModal.js
+++ b/components/VolunteerModal.js
@@ -109,7 +109,8 @@ export default function App(props) {
               styles.modalView,
               {
                 top: isWeb ? 120 : 0,
-                width: "100%"
+                width: "100%",
+                height: isWeb ? "100%" : null
               }
             ]}
           >

--- a/components/VolunteerModal.js
+++ b/components/VolunteerModal.js
@@ -1,64 +1,89 @@
-import React, { useState } from 'react';
-import { Alert, Modal, StyleSheet, Text, TouchableHighlight, View, Button } from 'react-native';
-import { getStyles, Theme } from '../utils';
-import { FontAwesome } from '@expo/vector-icons'; 
+import React, { useState } from "react";
+import { useStateValue } from "../components/State";
+import {
+  Alert,
+  Modal,
+  StyleSheet,
+  Text,
+  TouchableHighlight,
+  View,
+  Button
+} from "react-native";
+import { getStyles, Theme } from "../utils";
+import { FontAwesome } from "@expo/vector-icons";
 import { Link } from "../components/Link";
+import { ResponsiveImage } from "../components/ResponsiveImage";
 
 export default function App(props) {
-
   const { open, data, close, isWeb } = props;
+  const [{ dimensions }] = useStateValue();
 
-  let _styles1 = getStyles('text_body2, text_header2, text_header3, button_green, button_green_text, text_header4, section, content', { isWeb });
+  let _styles1 = getStyles(
+    "text_body2, text_header2, text_header3, button_green, button_green_text, text_header4, section, content",
+    { isWeb }
+  );
   let _styles = {
     centeredView: {
       flex: 1,
-      justifyContent: 'center',
-      alignItems: 'center',
+      justifyContent: "center",
+      alignItems: "center"
     },
     modalView: {
-      backgroundColor: 'white',
-      padding: 20,
-      alignItems: 'flex-start',
-      shadowColor: '#000',
+      backgroundColor: "white",
+      // padding: 20,
+      alignItems: "flex-start",
+      shadowColor: "#000",
       shadowOffset: {
         width: 0,
-        height: 2,
+        height: 2
       },
       shadowOpacity: 0.25,
       shadowRadius: 3.84,
-      elevation: 5,
+      elevation: 5
+    },
+    volunteerDetailItem: {
+      marginTop: 10,
+      marginBottom: 5
     }
-  }
-  const styles = StyleSheet.create({..._styles1, ..._styles});
+  };
+  const styles = StyleSheet.create({ ..._styles1, ..._styles });
 
-  console.log('modal visible', open)
+  console.log("modal visible", open);
 
   function WebWrapper(props) {
-    return props.isWeb ? 
-      <View style={{
-        zIndex: 3,
-        elevation: 3,
-        opacity: open ? 1 : 0,
-        pointerEvents: open ? '': 'none',
-        position: 'fixed',
-        top: 0,
-        bottom: 0,
-        right: 0,
-        left: 0,
-        backgroundColor: 'rgba(0,0,0,0.5)',
-        alignItems: 'center',
-        justifyContent: 'center',
-        flexDirection: 'row'
-      }} onClick={e => {
-        close();
-      }}>
-        <View style={{width: 500, maxWidth: '100%', margin: '0 auto'}} onClick={e => {
-          e.stopPropagation();
-        }}>
+    return isWeb ? (
+      <View
+        style={{
+          zIndex: 3,
+          elevation: 3,
+          opacity: open ? 1 : 0,
+          pointerEvents: open ? "" : "none",
+          position: "fixed",
+          top: 100,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          backgroundColor: "rgba(0,0,0,0.5)",
+          alignItems: "center",
+          justifyContent: "center",
+          flexDirection: "row"
+        }}
+        onClick={(e) => {
+          close();
+        }}
+      >
+        <View
+          style={{ width: 500, maxWidth: "100%", margin: "0 auto" }}
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
           {props.children}
         </View>
       </View>
-     : (<React.Fragment>{props.children}</React.Fragment>)
+    ) : (
+      <React.Fragment>{props.children}</React.Fragment>
+    );
   }
 
   return (
@@ -69,62 +94,200 @@ export default function App(props) {
         visible={open}
         presentationStyle="overFullScreen"
         onRequestClose={() => {
-          close()
-        }} style={{borderColor: 'transparent'}}>
-        <View style={[styles.centeredView, isWeb ? {width: '100%'} : {}]}>
+          close();
+        }}
+        style={{ borderColor: "transparent" }}
+      >
+        <View style={[styles.centeredView, isWeb ? { width: "100%" } : {}]}>
           <View style={styles.modalView}>
-
-            <View>
-              <Text style={styles.text_header4}>{data.name}</Text>
-            </View>
-            <View>
-              <Text style={styles.text_header4}>{data.role}</Text>
-            </View>
-            <View style={{marginTop: 10, marginBottom: 10}}>
-              <Text style={styles.text_body2}>{data.description}</Text>
-            </View>
-
-            {!!data.date_started && <View>
-              <Text style={styles.text_body2}>Started on {data.date_started}</Text>
-            </View>}
-            {!!data.amount && <View>
-              <Text style={styles.text_body2}>${data.amount} in time volunteered</Text>
-            </View>}
-
-            {data.links && data.links.length > 0 && <View style={{flexDirection: 'row', marginTop: 20}}>
-              {data.links.map(link => (
-                  <View style={{flexDirection: 'row', alignItems: 'center', marginRight: 20}}>
-                      <Link href={link.link}>
-
-                          {link && link.link_title && link.link_title.toLowerCase().indexOf('instagram') > -1 && 
-                            <FontAwesome name="instagram" size={16} color="#B56230" style={{marginRight: 10}} />}
-                          {link && link.link_title && link.link_title.toLowerCase().indexOf('site') > -1 && 
-                            <FontAwesome name="link" size={16} color="#B56230" style={{marginRight: 10}} />}
-
-                          <Text style={styles.text_body2}>
-                              {link.link_title}
-                          </Text>
-                      </Link>
+            <View
+              style={{
+                minWidth: "100%",
+                top: !isWeb ? 100 : null
+              }}
+            >
+              {data.image && data.image.url && (
+                <ResponsiveImage
+                  style={{
+                    minWidth: dimensions.width,
+                    width: data.image.width,
+                    height: data.image.height
+                  }}
+                  source={{ uri: data.image.url + "&w=600" }}
+                />
+              )}
+              <View
+                style={{
+                  marginHorizontal: 10
+                }}
+              >
+                <View>
+                  <Text style={styles.text_header3}>{data.name}</Text>
+                </View>
+                <View>
+                  <Text style={styles.text_header4}>{data.role}</Text>
+                </View>
+                <View style={styles.volunteerDetailItem}>
+                  <Text style={styles.text_body2}>{data.description}</Text>
+                </View>
+                {!!data._date_started && (
+                  <View style={styles.volunteerDetailItem}>
+                    {!!isWeb ? (
+                      <Text style={styles.text_body2}>
+                        Started on:
+                        {" " +
+                          new Date(
+                            data._date_started.value
+                          ).toLocaleDateString()}
+                      </Text>
+                    ) : (
+                      <Text style={styles.text_body2}>
+                        Started on:
+                        {" " +
+                          Date(
+                            new Date(
+                              data._date_started.value
+                            ).toLocaleDateString()
+                          ).slice(4, 15)}
+                      </Text>
+                    )}
                   </View>
-              ))}
-            </View>}
+                )}
+                {!!data.amount && (
+                  <View style={styles.volunteerDetailItem}>
+                    <Text style={styles.text_body2}>
+                      ${data.amount} in time volunteered
+                    </Text>
+                  </View>
+                )}
 
-            {!!data.talents_donated && <View style={{borderTopWidth: 1, borderTopColor: '#999', marginTop: 20, marginBottom: 10, paddingTop: 20, paddingbottom: 20}}>
-              <Text style={[styles.text_body2, {fontWeight: 'bold'}]}>SKILLS</Text>
-              <View style={{marginTop: 10, flexDirection: 'row'}}>
-                {data.talents_donated.map((talent, i, ar) => (<Text style={[styles.text_body2, {fontSize: 14}]}>{talent.talent}{i < ar.length-1 && ', '}</Text>))}
+                {data.links && data.links.length > 0 && (
+                  <View style={{ flexDirection: "row", marginTop: 20 }}>
+                    {data.links.map((link) => (
+                      <View
+                        style={{
+                          flexDirection: "row",
+                          alignItems: "center",
+                          marginRight: 20
+                        }}
+                      >
+                        <Link href={link.link}>
+                          <Text style={styles.text_body2}>
+                            {link &&
+                              link.link_title &&
+                              link.link_title
+                                .toLowerCase()
+                                .indexOf("instagram") > -1 && (
+                                <FontAwesome
+                                  name="instagram"
+                                  size={16}
+                                  color="#B56230"
+                                  style={{ marginRight: 10 }}
+                                />
+                              )}
+                            {link &&
+                              link.link_title &&
+                              link.link_title.toLowerCase().indexOf("site") >
+                                -1 && (
+                                <FontAwesome
+                                  name="link"
+                                  size={16}
+                                  color="#B56230"
+                                  style={{ marginRight: 10 }}
+                                />
+                              )}
+                            {link &&
+                              link.link_title &&
+                              link.link_title
+                                .toLowerCase()
+                                .indexOf("portfolio") > -1 && (
+                                <FontAwesome
+                                  name="link"
+                                  size={16}
+                                  color="#B56230"
+                                  style={{ marginRight: 10 }}
+                                />
+                              )}
+                            {link &&
+                              link.link_title &&
+                              link.link_title
+                                .toLowerCase()
+                                .indexOf("linkedin") > -1 && (
+                                <FontAwesome
+                                  name="linkedin"
+                                  size={16}
+                                  color="#B56230"
+                                  style={{ marginRight: 10 }}
+                                />
+                              )}
+                            {link &&
+                              link.link_title &&
+                              link.link_title.toLowerCase().indexOf("twitter") >
+                                -1 && (
+                                <FontAwesome
+                                  name="twitter"
+                                  size={16}
+                                  color="#B56230"
+                                  style={{ marginRight: 10 }}
+                                />
+                              )}
+
+                            {isWeb ? link.link_title : " " + link.link_title}
+                          </Text>
+                        </Link>
+                      </View>
+                    ))}
+                  </View>
+                )}
+
+                {!!data.talents_donated && (
+                  <View
+                    style={{
+                      flex: 1,
+                      borderTopWidth: 1,
+                      borderTopColor: "#999",
+                      marginTop: 20,
+                      marginBottom: 10,
+                      paddingTop: 20,
+                      paddingbottom: 20
+                    }}
+                  >
+                    <Text style={[styles.text_body2, { fontWeight: "bold" }]}>
+                      SKILLS
+                    </Text>
+                    <View
+                      style={{
+                        marginTop: 10,
+                        flexDirection: "row",
+                        flexWrap: "wrap"
+                      }}
+                    >
+                      {data.talents_donated.map((talent, i, ar) => (
+                        <Text style={[styles.text_body2, { fontSize: 14 }]}>
+                          {talent.talent}
+                          {i < ar.length - 1 && ", "}
+                        </Text>
+                      ))}
+                    </View>
+                  </View>
+                )}
               </View>
-            </View>}
 
-            <View style={{marginTop: 20}}>
-              <Button
+              <View
+                style={{
+                  position: "absolute",
+                  top: !isWeb ? 50 : 0,
+                  right: 0
+                }}
+              >
+                <Button
                   onPress={close}
-                  title="Close"
+                  title="X"
                   color={Theme.green}
                   style={styles.button_green}
-              />
+                />
+              </View>
             </View>
-
           </View>
         </View>
       </Modal>

--- a/components/VolunteerModal.js
+++ b/components/VolunteerModal.js
@@ -3,6 +3,7 @@ import { useStateValue } from "../components/State";
 import {
   Alert,
   Modal,
+  ScrollView,
   StyleSheet,
   Text,
   TouchableHighlight,
@@ -30,7 +31,6 @@ export default function App(props) {
     },
     modalView: {
       backgroundColor: "white",
-      // padding: 20,
       alignItems: "flex-start",
       shadowColor: "#000",
       shadowOffset: {
@@ -59,7 +59,7 @@ export default function App(props) {
           opacity: open ? 1 : 0,
           pointerEvents: open ? "" : "none",
           position: "fixed",
-          top: 100,
+          top: 0,
           bottom: 0,
           left: 0,
           right: 0,
@@ -73,7 +73,12 @@ export default function App(props) {
         }}
       >
         <View
-          style={{ width: 500, maxWidth: "100%", margin: "0 auto" }}
+          style={{
+            width: isWeb ? 500 : "100%",
+            maxWidth: "100%",
+            height: "100%",
+            margin: "0 auto"
+          }}
           onClick={(e) => {
             e.stopPropagation();
           }}
@@ -99,11 +104,18 @@ export default function App(props) {
         style={{ borderColor: "transparent" }}
       >
         <View style={[styles.centeredView, isWeb ? { width: "100%" } : {}]}>
-          <View style={styles.modalView}>
+          <ScrollView
+            contentContainerStyle={[
+              styles.modalView,
+              {
+                top: isWeb ? 120 : 0,
+                width: "100%"
+              }
+            ]}
+          >
             <View
               style={{
-                minWidth: "100%",
-                top: !isWeb ? 100 : null
+                width: "100%"
               }}
             >
               {data.image && data.image.url && (
@@ -271,13 +283,33 @@ export default function App(props) {
                     </View>
                   </View>
                 )}
+                <View
+                  style={{
+                    position: "relative",
+                    bottom: isWeb ? -20 : 0,
+                    alignSelf: "center",
+                    padding: 30,
+                    minWidth: 200,
+                    minHeight: "150%"
+                  }}
+                >
+                  <Button
+                    onPress={close}
+                    title="Close"
+                    color={Theme.green}
+                    style={[styles.button_green, { fontSize: 40 }]}
+                    accessibilityLabel="Close the pop-up screen with volunteer details"
+                  />
+                </View>
               </View>
 
               <View
                 style={{
                   position: "absolute",
-                  top: !isWeb ? 50 : 0,
-                  right: 0
+                  top: 0,
+                  right: 0,
+                  minWidth: 40,
+                  minHeight: 40
                 }}
               >
                 <Button
@@ -288,7 +320,7 @@ export default function App(props) {
                 />
               </View>
             </View>
-          </View>
+          </ScrollView>
         </View>
       </Modal>
     </WebWrapper>

--- a/screens/Press.js
+++ b/screens/Press.js
@@ -1,152 +1,192 @@
-import React, {useState, useEffect} from 'react';
+import React, { useState, useEffect } from "react";
 import { useStateValue } from "../components/State";
-import {View, Text, StyleSheet, Button, Platform, ActivityIndicator, FlatList, Image} from 'react-native';
+import {
+  View,
+  TouchableOpacity,
+  Text,
+  StyleSheet,
+  Button,
+  Platform,
+  ActivityIndicator,
+  FlatList,
+  Image
+} from "react-native";
 import { Link } from "../components/Link";
-import { PageTitle } from "../components/PageTitle"; 
-import { RichText } from "../components/RichText"; 
-import { getStyles, Theme, getContent, getData } from '../utils';
-import { ResponsiveImage } from "../components/ResponsiveImage"
+import { PageTitle } from "../components/PageTitle";
+import { RichText } from "../components/RichText";
+import { getStyles, Theme, getContent, getData } from "../utils";
+import { ResponsiveImage } from "../components/ResponsiveImage";
 
 function Page(props) {
-
-    const [{ view, isWeb, dimensions }, dispatch] = useStateValue();
-    const styles = StyleSheet.create(getStyles('text_header2, text_header4, text_header5, section, content', {isWeb}));
-
-    const [ pageLoading, setPageLoading ] = useState(props.content ? false: true);
-    const [ content, setContent ] = useState(props.content || {});
-
-    const [ loadingPress, setLoadingPress ] = useState(!props.press);
-    const [ errorPress, setErrorPress ] = useState('');
-    const [ press, setPress ] = useState(props.press || []);
-
-    if (!props.content) {
-        useEffect(() => {
-            getContent({type: 'content', uid: 'press'}).then(_content => {
-                setContent(_content.content)
-                setPageLoading(false);
-            }).catch(err => {
-                console.error(err);
-            });
-        }, [])
-    }
-
-    useEffect( () => {
-        if (!props.press) {
-            getData({
-                type: 'press'
-            }).then(press => {
-                setLoadingPress(false);
-                setPress(press)
-            }).catch(err => {
-                console.error(err);
-                setLoadingPress(false);
-                setErrorPress('Failed to load press.');
-            })
-        }
-    }, [])
-
-    let numColumns = dimensions.width < 600 ? 1 : dimensions.width < 1000 ? 2 : 3
-
-    let hasBody = content.body && content.body.join('');
-
-    return (
-        <React.Fragment>
-        { pageLoading ?
-            <View style={{marginTop: 200, marginBottom: 200}}>
-                <ActivityIndicator color={Theme.green} size="large" />
-            </View>
-        : (
-            <React.Fragment>
-                <PageTitle title={content.page_title} />
-                {!!hasBody && <View style={[styles.section]}>
-                    <View style={styles.content}>
-                        <RichText render={content._body} isWeb={isWeb} />
-                    </View>
-                </View>}
-                <View style={[styles.section]} nativeID="pressLinks">
-                    <View style={styles.content}>
-                        {loadingPress ? (
-                            <ActivityIndicator color={Theme.green} size="large" />
-                        ) : errorPress ? (
-                            <Text>{errorPress}</Text>
-                        ) : (
-                            <FlatList
-                                key={'cols' + numColumns}
-                                data={press}
-                                numColumns={numColumns}
-                                renderItem={({ item, index, separators }) => (
-                                    <View
-                                    style={{ flexDirection: "row" }}
-                                    key={'press' + index}
-                                    style={{
-                                        flex: 1/numColumns,
-                                        margin: 10,
-                                        borderTopWidth: 2,
-                                        borderColor: Theme.green,
-                                        shadowColor: "#000",
-                                        shadowOffset: {
-                                            width: 0,
-                                            height: 3,
-                                        },
-                                        shadowOpacity: 0.27,
-                                        shadowRadius: 4.65,
-
-                                        elevation: 6,
-                                    }}
-                                    >
-                                        {item.image && item.image.url && (
-                                        <ResponsiveImage style={{
-                                        maxWidth: '100%',
-                                        width: item.image.width,
-                                        height: item.image.height
-                                        }}
-                                        source={{uri: item.image.url + '&w=600'}} />
-                                        )}
-
-                                        <View
-                                            style={{
-                                                flex: 1,
-                                                padding: 20
-                                            }}
-                                        >
-                                            <View>
-                                                <Text>{item.date}</Text>
-                                                <Text style={styles.text_header5}>{item.title}</Text>
-                                            </View>
-                
-                                            {!!item.action_text && !!item.link && (
-                                                <View style={{ marginTop: "auto" }}>
-                                                <Link href={item.link}>
-                                                    <View>
-                                                        <Text style={[styles.text_header4]}>{item.action_text} &gt;</Text>
-                                                    </View>
-                                                </Link>
-                                            </View>
-                                            )}
-
-                                            {!!(item.attribution && item.attribution.length) && (
-                                                <Attribution attribution={item.attribution} />
-                                            )}
-                                        </View>
-                                    </View>
-                                )}
-                                keyExtractor={(item, index) => 'press' + index}
-                            />
-                        )}
-                    </View>
-                </View>
-            </React.Fragment>
-        )}
-        </React.Fragment>
+  const [{ view, isWeb, dimensions }, dispatch] = useStateValue();
+  const styles = StyleSheet.create(
+    getStyles(
+      "text_header2, text_header4, text_header5, section, content, button_green, button_green_text,",
+      {
+        isWeb
+      }
     )
+  );
+
+  const [pageLoading, setPageLoading] = useState(props.content ? false : true);
+  const [content, setContent] = useState(props.content || {});
+
+  const [loadingPress, setLoadingPress] = useState(!props.press);
+  const [errorPress, setErrorPress] = useState("");
+  const [press, setPress] = useState(props.press || []);
+
+  if (!props.content) {
+    useEffect(() => {
+      getContent({ type: "content", uid: "press" })
+        .then((_content) => {
+          setContent(_content.content);
+          setPageLoading(false);
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    }, []);
+  }
+
+  useEffect(() => {
+    if (!props.press) {
+      getData({
+        type: "press"
+      })
+        .then((press) => {
+          setLoadingPress(false);
+          setPress(press);
+        })
+        .catch((err) => {
+          console.error(err);
+          setLoadingPress(false);
+          setErrorPress("Failed to load press.");
+        });
+    }
+  }, []);
+
+  let numColumns = dimensions.width < 600 ? 1 : dimensions.width < 1000 ? 2 : 3;
+
+  let hasBody = content.body && content.body.join("");
+  // console.log(content.body);
+  // console.log(hasBody);
+
+  return (
+    <React.Fragment>
+      {pageLoading ? (
+        <View style={{ marginTop: 200, marginBottom: 200 }}>
+          <ActivityIndicator color={Theme.green} size="large" />
+        </View>
+      ) : (
+        <React.Fragment>
+          <PageTitle title={content.page_title} />
+          {!!hasBody && (
+            <View style={[styles.section]}>
+              <View style={styles.content}>
+                <RichText render={content._body} isWeb={isWeb} />
+                <TouchableOpacity
+                  style={[
+                    styles.button_green,
+                    {
+                      alignSelf: "flex-start"
+                    }
+                  ]}
+                >
+                  <Text style={styles.button_green_text}>
+                    {`See our Press Kit`.toUpperCase()}
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          )}
+          <View style={[styles.section]} nativeID="pressLinks">
+            <View style={styles.content}>
+              {loadingPress ? (
+                <ActivityIndicator color={Theme.green} size="large" />
+              ) : errorPress ? (
+                <Text>{errorPress}</Text>
+              ) : (
+                <FlatList
+                  key={"cols" + numColumns}
+                  data={press}
+                  numColumns={numColumns}
+                  renderItem={({ item, index, separators }) => (
+                    <View
+                      style={{ flexDirection: "row" }}
+                      key={"press" + index}
+                      style={{
+                        flex: 1 / numColumns,
+                        margin: 10,
+                        borderTopWidth: 2,
+                        borderColor: Theme.green,
+                        shadowColor: "#000",
+                        shadowOffset: {
+                          width: 0,
+                          height: 3
+                        },
+                        shadowOpacity: 0.27,
+                        shadowRadius: 4.65,
+
+                        elevation: 6
+                      }}
+                    >
+                      {item.image && item.image.url && (
+                        <ResponsiveImage
+                          style={{
+                            maxWidth: "100%",
+                            width: item.image.width,
+                            height: item.image.height
+                          }}
+                          source={{ uri: item.image.url + "&w=600" }}
+                        />
+                      )}
+
+                      <View
+                        style={{
+                          flex: 1,
+                          padding: 20
+                        }}
+                      >
+                        <View>
+                          <Text>{item.date}</Text>
+                          <Text style={styles.text_header5}>{item.title}</Text>
+                        </View>
+
+                        {!!item.action_text && !!item.link && (
+                          <View style={{ marginTop: "auto" }}>
+                            <Link href={item.link}>
+                              <View>
+                                <Text style={[styles.text_header4]}>
+                                  {item.action_text} &gt;
+                                </Text>
+                              </View>
+                            </Link>
+                          </View>
+                        )}
+
+                        {!!(item.attribution && item.attribution.length) && (
+                          <Attribution attribution={item.attribution} />
+                        )}
+                      </View>
+                    </View>
+                  )}
+                  keyExtractor={(item, index) => "press" + index}
+                />
+              )}
+            </View>
+          </View>
+        </React.Fragment>
+      )}
+    </React.Fragment>
+  );
 }
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-    }
-})
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center"
+  }
+});
 
 export default Page;

--- a/screens/Volunteers.js
+++ b/screens/Volunteers.js
@@ -1,176 +1,269 @@
-import React, {useState, useEffect} from 'react';
+import React, { useState, useEffect } from "react";
 import { useStateValue } from "../components/State";
-import {View, Text, StyleSheet, Button, Platform, ActivityIndicator, FlatList, Image, TouchableOpacity} from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Button,
+  Platform,
+  ActivityIndicator,
+  FlatList,
+  Image,
+  TouchableOpacity
+} from "react-native";
 import { Link } from "../components/Link";
-import { PageTitle } from "../components/PageTitle"; 
-import { RichText } from "../components/RichText"; 
-import { getStyles, Theme, getContent, getData } from '../utils';
-import { ResponsiveImage } from "../components/ResponsiveImage"
+import { PageTitle } from "../components/PageTitle";
+import { RichText } from "../components/RichText";
+import { getStyles, Theme, getContent, getData } from "../utils";
+import { ResponsiveImage } from "../components/ResponsiveImage";
 import VolunteerModal from "../components/VolunteerModal";
 
 function Page(props) {
-
-    const [{ view, isWeb, dimensions }, dispatch] = useStateValue();
-    const styles = StyleSheet.create(getStyles('text_header2, text_header3, text_header4, text_header5, section, content', {isWeb}));
-
-    const [ pageLoading, setPageLoading ] = useState(props.content ? false: true);
-    const [ content, setContent ] = useState(props.content || {});
-
-    const [ loadingVolunteers, setLoadingVolunteers ] = useState(!props.volunteers);
-    const [ errorVolunteers, setErrorVolunteers ] = useState('');
-    const [ volunteers, setVolunteers ] = useState(props.volunteers || []);
-
-    const [ modalOpen, setModalOpen ] = useState(false);
-    const [ modalData, setModalData ] = useState({});
-
-    function closeModal() {
-        setModalOpen(false);
-    }
-
-    if (!props.content) {
-        useEffect(() => {
-            getContent({type: 'content', uid: 'volunteers'}).then(_content => {
-                setContent(_content.content)
-                setPageLoading(false);
-            }).catch(err => {
-                console.error(err);
-            });
-        }, [])
-    }
-
-    useEffect( () => {
-        if (!props.volunteers) {
-            getData({
-                type: 'volunteers'
-            }).then(_volunteers => {
-                setLoadingVolunteers(false);
-                setVolunteers(_volunteers)
-            }).catch(err => {
-                console.error(err);
-                setLoadingVolunteers(false);
-                setErrorVolunteers('Failed to load volunteers.');
-            })
-        }
-    }, [])
-
-    let numColumns = dimensions.width < 600 ? 1 : 2
-    let hasBody = content.body && content.body.join('');
-
-    let stats = {
-        count: 200,
-        hours: 10000,
-        dollars: 700000
-    };
-    volunteers.forEach(volunteer => {
-        stats.count++;
-        stats.dollars += (volunteer.amount || 0);
-        stats.hours += volunteer.amount ? (volunteer.amount / 100) : 0
-    })
-    console.log('volunteers', volunteers);
-
-    let shuffledVolunteers = volunteers.sort( () => Math.random() - 0.5 );
-
-    return (
-        <React.Fragment>
-        { pageLoading ?
-            <View style={{marginTop: 200, marginBottom: 200}}>
-                <ActivityIndicator color={Theme.green} size="large" />
-            </View>
-        : (
-            <React.Fragment>
-                <PageTitle navigation={props.navigation} title={content.page_title} button={{
-                    title: 'Get Involved',
-                    href: '/volunteer',
-                    nav: 'Volunteer'
-                }}/>
-                {!!hasBody && <View style={[styles.section]}>
-                    <View style={styles.content}>
-                        <RichText render={content._body} isWeb={isWeb} />
-                    </View>
-                </View>}
-                {loadingVolunteers ? (
-                    <ActivityIndicator color={Theme.green} size="large" />
-                ) : errorVolunteers ? (
-                    <Text>{errorVolunteers}</Text>
-                ) : (
-                    <View>
-                        <VolunteerModal open={modalOpen} data={modalData} close={closeModal} isWeb={isWeb} />
-                        <View style={[styles.section, {backgroundColor: '#F2F2F2'}]}>
-                            <View style={[styles.content, {flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', textAlign: 'center'}]}>
-                                <View>
-                                    <Text style={[styles.text_body, {fontSize: 40, fontWeight: 'bold', marginBottom: 10}]}>{stats.count}+</Text>
-                                    <Text>total volunteers</Text>
-                                </View>
-                                <View>
-                                    <Text style={[styles.text_body, {fontSize: 40, fontWeight: 'bold', marginBottom: 10}]}>{Math.round(stats.hours)}+</Text>
-                                    <Text>hours donated</Text>
-                                </View>
-                                <View>
-                                    <Text style={[styles.text_body, {fontSize: 40, fontWeight: 'bold', marginBottom: 10}]}>${(Math.round(stats.dollars/1000))}K+</Text>
-                                    <Text>in time volunteered</Text>
-                                </View>
-                            </View>
-                        </View>
-                        <View style={[styles.section]} nativeID="volunteersLinks">
-                            <View style={styles.content}>
-                                <FlatList
-                                    key={'cols' + numColumns}
-                                    data={shuffledVolunteers}
-                                    numColumns={numColumns}
-                                    renderItem={({ item, index, separators }) => (
-                                        <View
-                                        style={{ flexDirection: "row" }}
-                                        key={'volunteers' + index}
-                                        style={{
-                                            flex: 1/numColumns,
-                                            margin: 10,
-                                            elevation: 6,
-                                        }}
-                                        >
-                                            <TouchableOpacity onPress={e => { setModalData(item); setModalOpen(true);}}>
-                                                <View style={{flexDirection: 'row'}}>
-                                                    <View style={{flex: 1}}>
-                                                        {item.image && item.image.url && (
-                                                        <ResponsiveImage style={{
-                                                        maxWidth: '100%',
-                                                        width: item.image.width,
-                                                        height: item.image.height
-                                                        }}
-                                                        source={{uri: item.image.url + '&w=600'}} />
-                                                        )}
-                                                    </View>
-                                                    <View style={{flex: 2, paddingLeft: 20}}>
-                                                        <View>
-                                                            <Text style={styles.text_header4}>{item.name}</Text>
-                                                            <Text style={[styles.text_header4, {fontSize: 18, paddingBottom: 4, paddingTop: 4}]}>{item.role || ''}</Text>
-                                                            <View style={{maxHeight: 50, overflow: 'hidden'}}>
-                                                                <Text style={[styles.text_body]}>{item.description || ''} ...</Text>
-                                                            </View>
-                                                            {/*<Text style={[styles.text_body, {color: Theme.green, marginTop: 20}]}>See full bio</Text>*/}
-                                                        </View>
-                                                    </View>
-                                                </View>
-                                            </TouchableOpacity>
-                                        </View>
-                                    )}
-                                    keyExtractor={(item, index) => 'volunteers' + index}
-                                />
-                            </View>
-                        </View>
-                    </View>
-                )}
-            </React.Fragment>
-        )}
-        </React.Fragment>
+  const [{ view, isWeb, dimensions }, dispatch] = useStateValue();
+  const styles = StyleSheet.create(
+    getStyles(
+      "text_header2, text_header3, text_header4, text_header5, section, content",
+      { isWeb }
     )
+  );
+
+  const [pageLoading, setPageLoading] = useState(props.content ? false : true);
+  const [content, setContent] = useState(props.content || {});
+
+  const [loadingVolunteers, setLoadingVolunteers] = useState(!props.volunteers);
+  const [errorVolunteers, setErrorVolunteers] = useState("");
+  const [volunteers, setVolunteers] = useState(props.volunteers || []);
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalData, setModalData] = useState({});
+
+  function closeModal() {
+    setModalOpen(false);
+  }
+
+  if (!props.content) {
+    useEffect(() => {
+      getContent({ type: "content", uid: "volunteers" })
+        .then((_content) => {
+          setContent(_content.content);
+          setPageLoading(false);
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    }, []);
+  }
+
+  useEffect(() => {
+    if (!props.volunteers) {
+      getData({
+        type: "volunteers"
+      })
+        .then((_volunteers) => {
+          setLoadingVolunteers(false);
+          setVolunteers(_volunteers);
+        })
+        .catch((err) => {
+          console.error(err);
+          setLoadingVolunteers(false);
+          setErrorVolunteers("Failed to load volunteers.");
+        });
+    }
+  }, []);
+
+  let numColumns = dimensions.width < 600 ? 1 : 2;
+  let hasBody = content.body && content.body.join("");
+
+  let stats = {
+    count: 200,
+    hours: 10000,
+    dollars: 700000
+  };
+  volunteers.forEach((volunteer) => {
+    stats.count++;
+    stats.dollars += volunteer.amount || 0;
+    stats.hours += volunteer.amount ? volunteer.amount / 100 : 0;
+  });
+  console.log("volunteers", volunteers);
+
+  let shuffledVolunteers = volunteers.sort(() => Math.random() - 0.5);
+
+  return (
+    <React.Fragment>
+      {pageLoading ? (
+        <View style={{ marginTop: 200, marginBottom: 200 }}>
+          <ActivityIndicator color={Theme.green} size="large" />
+        </View>
+      ) : (
+        <React.Fragment>
+          <PageTitle
+            navigation={props.navigation}
+            title={content.page_title}
+            button={{
+              title: "Get Involved",
+              href: "/volunteer",
+              nav: "Volunteer"
+            }}
+          />
+          {!!hasBody && (
+            <View style={[styles.section]}>
+              <View style={styles.content}>
+                <RichText render={content._body} isWeb={isWeb} />
+              </View>
+            </View>
+          )}
+          {loadingVolunteers ? (
+            <ActivityIndicator color={Theme.green} size="large" />
+          ) : errorVolunteers ? (
+            <Text>{errorVolunteers}</Text>
+          ) : (
+            <View>
+              <VolunteerModal
+                open={modalOpen}
+                data={modalData}
+                close={closeModal}
+                isWeb={isWeb}
+              />
+              <View style={[styles.section, { backgroundColor: "#F2F2F2" }]}>
+                <View
+                  style={[
+                    styles.content,
+                    {
+                      flexDirection: "row",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      textAlign: "center",
+                      marginTop: 20
+                    }
+                  ]}
+                >
+                  <View>
+                    <Text
+                      style={
+                        ([styles.text_body, styles.statsItem],
+                        { fontSize: dimensions.width < 980 ? 26 : 40 })
+                      }
+                    >
+                      {stats.count}+
+                    </Text>
+                    <Text>total volunteers</Text>
+                  </View>
+                  <View>
+                    <Text
+                      style={
+                        ([styles.text_body, styles.statsItem],
+                        { fontSize: dimensions.width < 980 ? 26 : 40 })
+                      }
+                    >
+                      {Math.round(stats.hours)}+
+                    </Text>
+                    <Text>hours donated</Text>
+                  </View>
+                  <View>
+                    <Text
+                      style={
+                        ([styles.text_body, styles.statsItem],
+                        { fontSize: dimensions.width < 980 ? 26 : 40 })
+                      }
+                    >
+                      ${Math.round(stats.dollars / 1000)}K+
+                    </Text>
+                    <Text>in time volunteered</Text>
+                  </View>
+                </View>
+              </View>
+              <View style={[styles.section]} nativeID="volunteersLinks">
+                <View style={styles.content}>
+                  <FlatList
+                    key={"cols" + numColumns}
+                    data={shuffledVolunteers}
+                    numColumns={numColumns}
+                    renderItem={({ item, index, separators }) => (
+                      <View
+                        style={{ flexDirection: "row" }}
+                        key={"volunteers" + index}
+                        style={{
+                          flex: 1 / numColumns,
+                          margin: 10,
+                          elevation: 6
+                        }}
+                      >
+                        <TouchableOpacity
+                          onPress={(e) => {
+                            console.log(item);
+                            setModalData(item);
+                            setModalOpen(true);
+                          }}
+                        >
+                          <View
+                            style={{ flexDirection: "row", minHeight: 115 }}
+                          >
+                            <View style={{ flex: 1 }}>
+                              {item.image && item.image.url && (
+                                <ResponsiveImage
+                                  style={{
+                                    width: item.image.width,
+                                    height: item.image.height
+                                  }}
+                                  source={{ uri: item.image.url + "&w=600" }}
+                                />
+                              )}
+                            </View>
+                            <View style={{ flex: 2, paddingLeft: 20 }}>
+                              <View>
+                                <Text style={styles.text_header4}>
+                                  {item.name}
+                                </Text>
+                                <Text
+                                  style={[
+                                    styles.text_header4,
+                                    {
+                                      fontSize: 18,
+                                      paddingBottom: 4,
+                                      paddingTop: 4
+                                    }
+                                  ]}
+                                >
+                                  {item.role || ""}
+                                </Text>
+                              </View>
+                              <View>
+                                <View
+                                  style={{ maxHeight: 50, overflow: "hidden" }}
+                                >
+                                  <Text style={[styles.text_body]}>
+                                    {item.description || ""} ...
+                                  </Text>
+                                </View>
+                                {/*<Text style={[styles.text_body, {color: Theme.green, marginTop: 20}]}>See full bio</Text>*/}
+                              </View>
+                            </View>
+                          </View>
+                        </TouchableOpacity>
+                      </View>
+                    )}
+                    keyExtractor={(item, index) => "volunteers" + index}
+                  />
+                </View>
+              </View>
+            </View>
+          )}
+        </React.Fragment>
+      )}
+    </React.Fragment>
+  );
 }
 
 const styles = StyleSheet.create({
-    container: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-    }
-})
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center"
+  },
+  statsItem: {
+    fontWeight: "bold",
+    marginBottom: 10
+  }
+});
 
 export default Page;


### PR DESCRIPTION
Adjusted page as requested by Danilo in [issue# 238](https://github.com/spicygreenbook/greenbook-app/issues/238)

Someone with admin/edit rights to CMS needs to remove the text link "View our Press Kit" from /press page when deploying this, to prevent the double link+button combo as in current dev screenshot. I could have hacked it by removing last item from CMS array, but then that would remove whatever the last element is in future content edits, so didn't want to do that.

![localhost_3000_press (1)](https://user-images.githubusercontent.com/48567344/104798202-10916700-578a-11eb-9b44-2e539a55470d.png)
