### PR TITLE
Maintenance/bottom nav

### DIFF
--- a/navigations/BottomTabNavigator.js
+++ b/navigations/BottomTabNavigator.js
@@ -7,7 +7,7 @@ import HomeStackNavigator from './HomeStackNavigator';
 import BrowseStackNavigator from './BrowseStackNavigator';
 import AddListing from '../screens/AddListing';
 import Volunteer from '../screens/Volunteer';
-
+import { MaterialCommunityIcons } from '@expo/vector-icons';
 import { WithScrollView } from './helper';
 import CustomHeader from './CustomHeader';
 
@@ -31,6 +31,10 @@ const VolunteerStack = (props) => (
     }} />
   </VolunteerStackNavigator.Navigator>
 )
+
+//Placeholder component that will be used by the navigation button in the bottom bar but won't be rendered
+// a little unconventional but it's the easiest solution to bypass this required prop
+const Placeholder = () => (<> </>)
 
 const BottomTabNavigator = ({ navigation }) => {
 
@@ -84,6 +88,20 @@ const BottomTabNavigator = ({ navigation }) => {
           tabBarIcon: ({ color }) => <Icon type="FontAwesome5" style={{ fontSize: 22, color }} name="hands-helping" />
         }}
       />   
+      <BottomTab.Screen 
+        name="Navigation"
+        component={Placeholder}
+        options={{
+          tabBarLabel: null,
+          tabBarIcon: () => <MaterialCommunityIcons color="white" name="dots-vertical" size={28} />
+        }}
+        listeners={({ navigation }) => ({
+          tabPress: e => {
+            e.preventDefault()
+            navigation.openDrawer()
+          }
+        })}
+      />
     </BottomTab.Navigator>
   )
 };

--- a/navigations/BottomTabNavigator.js
+++ b/navigations/BottomTabNavigator.js
@@ -38,7 +38,7 @@ const BottomTabNavigator = ({ navigation }) => {
     <BottomTab.Navigator
       shifting={false}
       activeColor='white'
-      barStyle={{ backgroundColor: Theme.green, height: 100, paddingTop: 20 }}
+      barStyle={{ backgroundColor: Theme.green, height: 80, paddingTop: 10 }}
     >
       <BottomTab.Screen
         name="Home"

--- a/navigations/BottomTabNavigator.js
+++ b/navigations/BottomTabNavigator.js
@@ -42,7 +42,7 @@ const BottomTabNavigator = ({ navigation }) => {
     <BottomTab.Navigator
       shifting={false}
       activeColor='white'
-      barStyle={{ backgroundColor: Theme.green, height: 60, paddingTop: 10 }}
+      barStyle={{ backgroundColor: Theme.green, height: 75, paddingTop: 10 }}
     >
       <BottomTab.Screen
         name="Home"

--- a/navigations/BottomTabNavigator.js
+++ b/navigations/BottomTabNavigator.js
@@ -42,7 +42,7 @@ const BottomTabNavigator = ({ navigation }) => {
     <BottomTab.Navigator
       shifting={false}
       activeColor='white'
-      barStyle={{ backgroundColor: Theme.green, height: 80, paddingTop: 10 }}
+      barStyle={{ backgroundColor: Theme.green, height: 60, paddingTop: 10 }}
     >
       <BottomTab.Screen
         name="Home"
@@ -87,7 +87,10 @@ const BottomTabNavigator = ({ navigation }) => {
         options={{
           tabBarIcon: ({ color }) => <Icon type="FontAwesome5" style={{ fontSize: 22, color }} name="hands-helping" />
         }}
-      />   
+      />
+      {/* screen for the navigation button. Probably not the best way to implement it but it's the easiest and the only
+          solution i could think of that doesn't require redoing the whole bottom tab navigator
+      */}
       <BottomTab.Screen 
         name="Navigation"
         component={Placeholder}

--- a/navigations/CustomHeader.js
+++ b/navigations/CustomHeader.js
@@ -26,10 +26,10 @@ const CustomHeader = ({ navigation, backgroundColor, dark = false }) => {
         // backgroundColor: backgroundColor && backgroundColor
       }}>
         <TouchableOpacity onPress={() => navigation.navigate("Home")}>
-          <Image style={{ width: 110, height: 110, resizeMode: 'contain' }} alt="Spicy Green Book" source={LightNav} />
+          <Image style={{ width: 80, height: 80, resizeMode: 'contain' }} alt="Spicy Green Book" source={LightNav} />
         </TouchableOpacity>
         {/* <Text style={{ fontWeight: '800', fontSize: 16, color: Theme.green }}>{route.name}</Text> */}
-        <MaterialCommunityIcons color={dark ? Theme.green : 'white'} name="menu" size={34} onPress={() => navigation.openDrawer()} />
+        {/* <MaterialCommunityIcons color={dark ? Theme.green : 'white'} name="menu" size={34} onPress={() => navigation.openDrawer()} /> */}
       </View>
     </SafeAreaView>
   )


### PR DESCRIPTION
Transferred the nav button from the top bar to the bottom bar on the mobile app.

While doing so, discovered an issue with the nav drawer: 
(drawerContent is called twice, and the second one is rendered)
<img width="596" alt="Screenshot 2021-05-06 at 15 37 38" src="https://user-images.githubusercontent.com/60845154/117374181-8b89a500-ae81-11eb-8fb1-81a99bcc8473.png">
This code is using two version of the navigator drawer.

The one that's actively in the app is this one: 
<img width="300" alt="Simulator Screen Shot - iPhone SE (2nd generation) - 2021-05-06 at 15 37 56" src="https://user-images.githubusercontent.com/60845154/117374208-93e1e000-ae81-11eb-8e51-6535c0cba2bb.png">

While the one that is not rendered is this one: 
<img width="300" alt="Simulator Screen Shot - iPhone SE (2nd generation) - 2021-05-06 at 15 39 09" src="https://user-images.githubusercontent.com/60845154/117374210-95130d00-ae81-11eb-91cd-2e2756885101.png">
