### PR TITLE
407 [About Us] [Bug] Fix image overlap with text

### DIFF
--- a/screens/About.js
+++ b/screens/About.js
@@ -534,7 +534,7 @@ function Page(props) {
         </View>
         {dimensions.width >= 800 && (
           <View style={{ flex: 1, backgroundColor: "#ffffff", position: "relative" }}>
-            <View style={{ position: "absolute", left: -20, top: 20, width: "100%" }}>
+            <View style={{ position: "absolute", left: -20, top: 20, maxHeight: 550, width: "100%" }}>
               <ResponsiveImage
                 style={{ position: "relative", top: 50, width: 400, aspectRatio: 1 }}
                 alt="Spicy Green Book"


### PR DESCRIPTION
Fixed the height of the image container to 550px. It can be set from
a value ranging from 400px to 550px. 400px is the height of the
container that contains the text on the left-side of the images.

This will resolve #407

This was tested on (mac)
  * iPad Pro (12.9-inch) (4th generation) - iOS 14.4
  * iPhone 11 - iOS 14.4
  * Chorme Version 91.0.4472.106 (Official Build) (x86_64)
  * Firefox 89.0.1 (64-bit)
  
  
# Before Fix
<img width=500 src=https://user-images.githubusercontent.com/22308175/122487856-11286680-cf91-11eb-8966-9878644b9a56.jpg>


# After Fix
<img width=500 src=https://user-images.githubusercontent.com/22308175/122487864-171e4780-cf91-11eb-9301-5abb36af5dd7.jpg>
